### PR TITLE
[Refactor] Do not use ".exists()" method included in ".is_dir()" and …

### DIFF
--- a/src/lib/cmd_helper.rs
+++ b/src/lib/cmd_helper.rs
@@ -3,24 +3,27 @@ use std::fmt::Display;
 use std::path::Path;
 
 pub fn working_dir_exists() -> bool {
-    let path_to_dir = Path::new(WORKING_DIR_NAME).to_path_buf();
-    path_to_dir.exists() && path_to_dir.is_dir()
+    Path::new(WORKING_DIR_NAME)
+        .to_path_buf()
+        .is_dir()
 }
 pub fn print_warning_for_working_dir() {
     print_warning(format!("\"{}\" directory", WORKING_DIR_NAME));
 }
 
 pub fn config_file_exists() -> bool {
-    let path_to_file = Path::new(WORKING_DIR_NAME).join(CONFIG_FILE_NAME);
-    path_to_file.exists() && path_to_file.is_file()
+    Path::new(WORKING_DIR_NAME)
+        .join(CONFIG_FILE_NAME)
+        .is_file()
 }
 pub fn print_warning_for_config_file() {
     print_warning(format!("\"{}\" file", CONFIG_FILE_NAME));
 }
 
 pub fn ignore_file_exists() -> bool {
-    let path_to_file = Path::new(WORKING_DIR_NAME).join(IGNORE_FILE_NAME);
-    path_to_file.exists() && path_to_file.is_file()
+    Path::new(WORKING_DIR_NAME)
+        .join(IGNORE_FILE_NAME)
+        .is_file()
 }
 pub fn print_warning_for_ignore_file() {
     print_warning(format!("\"{}\" file", IGNORE_FILE_NAME));

--- a/src/lib/command.rs
+++ b/src/lib/command.rs
@@ -35,7 +35,7 @@ pub fn initialize() {
 
 fn create_setting_file<S: AsRef<str>>(path_to_file: PathBuf, contents: S) {
     let file_name = path_to_file.file_name().and_then(|f| f.to_str()).unwrap();
-    if path_to_file.exists() && path_to_file.is_file() {
+    if path_to_file.is_file() {
         println!("  OK: \"{}\" file has already exist.", file_name);
     } else {
         match File::create(&path_to_file) {
@@ -74,7 +74,7 @@ pub fn sweep() {
     let now           = Local::now();
     let trash_name    = format!("trash_{}", now.format("%Y-%m-%d"));
     let path_to_trash = Path::new(WORKING_DIR_NAME).join(trash_name);
-    if !(path_to_trash.exists() && path_to_trash.is_dir()) {
+    if !path_to_trash.is_dir() {
         match fs::create_dir(path_to_trash) {
             Ok(_)    => {},
             Err(why) => panic!("{:?}", why),


### PR DESCRIPTION
…".is_file()"

実際のところは「ディレクトリを望むのに、なぜかファイルが存在するなどのケース」をちゃんとケアしないといけないが、とりあえず無駄を削るのは大事だと考えて修正しておきました。
