### PR TITLE
[Refactor] Use filter_map()

### DIFF
--- a/src/lib/fs_helper.rs
+++ b/src/lib/fs_helper.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::result::Result;
 
 pub fn walk_dir<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
     fn walk_dir(path: PathBuf) -> Vec<OsString> {
@@ -10,9 +11,9 @@ pub fn walk_dir<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
             Err(why) => panic!("{:?}", why),
         };
         paths
-            .filter(|de| de.is_ok())
+            .filter_map(Result::ok)
             .flat_map(|de| {
-                let path = de.unwrap().path();
+                let path = de.path();
                 if is_hidden(&path) {
                     Vec::new()
                 } else if path.is_file() {
@@ -26,8 +27,7 @@ pub fn walk_dir<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
 
     walk_dir(path.as_ref().to_path_buf()).iter()
         .map(|f| f.clone().into_string())
-        .filter(|f| f.is_ok())
-        .map(|f| f.unwrap())
+        .filter_map(Result::ok)
         .collect::<BTreeSet<String>>()
 }
 


### PR DESCRIPTION
ひとまず`filter_map()`を使う方向で修正。思いの外すっきりと書けました。
`Result::iter()` + `flat_map()` の組み合わせは、ちょっと書いただけの感想としては非常に冗長な印象でした。

``` diff
diff --git a/src/lib/fs_helper.rs b/src/lib/fs_helper.rs
index 2e9df55..0a2801b 100644
--- a/src/lib/fs_helper.rs
+++ b/src/lib/fs_helper.rs
@@ -27,7 +27,7 @@ pub fn walk_dir<P: AsRef<Path>>(path: P) -> BTreeSet<String> {

     walk_dir(path.as_ref().to_path_buf()).iter()
         .map(|f| f.clone().into_string())
-        .filter_map(Result::ok)
+        .flat_map(|f| f.iter().cloned().collect::<Vec<String>>())
         .collect::<BTreeSet<String>>()
 }
```

--- 追記 ---
以下のようにもっとすっきりと書けた。ただし、`filter_map()`の方が処理効率は良さそうなので、`filter_map()`を採用する。

``` rust
.flat_map(Result::into_iter)
```
